### PR TITLE
installation instruction on docify website not working anymore

### DIFF
--- a/docs/_content/getting-started/index.md
+++ b/docs/_content/getting-started/index.md
@@ -12,7 +12,8 @@ Docify is available as [.NET Core Global Tool](https://docs.microsoft.com/en-us/
 Docify can be installed by running the following command:
 
 ~~~
-> dotnet install -g docify
+> dotnet tool install -g docify
+
 ~~~
 
 To update to newer version run


### PR DESCRIPTION
In VS Code:
And type in the terminal:
PS C:\Users\Eddy> dotnet install -g docify
gives error:
	Could not execute because the specified command or file was not found.
	Possible reasons for this include:
	  * You misspelled a built-in dotnet command.
	  * You intended to execute a .NET program, but dotnet-install does not exist.
	  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.

Solution: add tool keyword
dotnet tool install -g docify
You can invoke the tool using the following command: docify
Tool 'docify' (version '0.6.3') was successfully installed.